### PR TITLE
[Android] Added purchases restore callback to BillingListener class.

### DIFF
--- a/Android/iap/src/main/java/com/applicaster/iap/BillingListener.kt
+++ b/Android/iap/src/main/java/com/applicaster/iap/BillingListener.kt
@@ -29,6 +29,13 @@ interface BillingListener {
     fun onPurchaseLoadingFailed(@BillingClient.BillingResponse statusCode: Int, description: String)
 
     /**
+     * Implement this function to get restored purchases.
+     *
+     * @param purchases List of purchased items.
+     */
+    fun onPurchasesRestored(purchases: List<Purchase>)
+
+    /**
      * Implement this function to get list of In-app product's or subscription's details.
      * Will be called as a result of [BillingHelper.loadSkuDetails] function.
      *

--- a/Android/iap/src/main/java/com/applicaster/iap/GoogleBillingHelper.kt
+++ b/Android/iap/src/main/java/com/applicaster/iap/GoogleBillingHelper.kt
@@ -62,7 +62,7 @@ object GoogleBillingHelper : BillingHelper {
     }
 
     override fun validatePurchases(appPublicKey: String, purchases: List<Purchase>) {
-        // we should check app public key if it not empty and return empty list if it does
+        // we should check app public key if it's not empty and return empty list if it does
         if (appPublicKey.isEmpty()) {
             Log.w(TAG, "App public key should be not empty!")
             billingListener.onPurchaseLoaded(emptyList())
@@ -129,8 +129,8 @@ object GoogleBillingHelper : BillingHelper {
         val result = billingClient.queryPurchases(skuType)
         //if result isn't null set to callback purchases list else set empty list
         result?.also {
-            billingListener.onPurchaseLoaded(result.purchasesList)
-        } ?: billingListener.onPurchaseLoaded(listOf())
+            billingListener.onPurchasesRestored(it.purchasesList)
+        } ?: billingListener.onPurchasesRestored(listOf())
     }
 
     private fun querySkuDetails(skuType: String, skusList: List<String>) {


### PR DESCRIPTION
## Description
Added purchases restore callback instead of calling onPurchaseLoaded callback after restoring purchases.

## Known issues

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [x] Documentation is included

## QA :

* required test cases:
* specific apps / plugins to test :
