### PR TITLE
Wrap all completion to main thread for ios 13

### DIFF
--- a/Specs/ApplicasterIAP/0.0.5/ApplicasterIAP.podspec
+++ b/Specs/ApplicasterIAP/0.0.5/ApplicasterIAP.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = 'ApplicasterIAP'
+  s.version      = '0.0.5'
+  s.summary      = 'In App Purchases framework'
+  s.license      = 'MIT'
+  s.homepage     = 'https://github.com/applicaster/applicaster-iap-framework'
+  s.author       = { 'Roman Karpievich' => 'r.karpievich@applicaster.com' }
+  s.ios.deployment_target = '9.0'
+  s.swift_version = '4.2'
+  s.source       = { :git => "https://github.com/applicaster/applicaster-iap-framework", :tag => s.version }
+  s.source_files = 'iOS/ApplicasterIAP/*.{swift}'
+  s.requires_arc = true
+end

--- a/iOS/ApplicasterIAP/BillingHelper.swift
+++ b/iOS/ApplicasterIAP/BillingHelper.swift
@@ -40,7 +40,9 @@ open class BillingHelper {
                          completion: @escaping (ProductsQueryResult) -> Void) {
         productsQuery = ProductsQuery(identifiers: identifiers) { [weak self] (result) in
             self?.productsQuery = nil
-            completion(result)
+            DispatchQueue.main.async {
+                completion(result)
+            }
         }
         
         productsQuery?.start()
@@ -58,7 +60,9 @@ open class BillingHelper {
             let error = NSError(domain: SKErrorDomain,
                                 code: SKError.paymentNotAllowed.rawValue,
                                 userInfo: [NSLocalizedDescriptionKey: "Payments are blocked on this device"])
-            completion(.failure(error))
+            DispatchQueue.main.async {
+                completion(.failure(error))
+            }
             return
         }
         
@@ -86,7 +90,9 @@ open class BillingHelper {
         receiptRefreshQuery = ReceiptRefreshQuery(receiptProperties: receiptProperties,
                                                   completion: { [weak self] (result) in
             self?.receiptRefreshQuery = nil
-            completion(result)
+            DispatchQueue.main.async {
+                completion(result)
+            }
         })
         
         receiptRefreshQuery?.start()

--- a/iOS/ApplicasterIAP/StoreObserver.swift
+++ b/iOS/ApplicasterIAP/StoreObserver.swift
@@ -62,7 +62,9 @@ class StoreObserver: NSObject, SKPaymentTransactionObserver {
         purchase.transaction = transaction
         
         let result = PurchaseResult.success(purchase)
-        completion(result)
+        DispatchQueue.main.async {
+            completion(result)
+        }
         
         if purchase.finishing == true {
             SKPaymentQueue.default().finishTransaction(transaction)
@@ -82,7 +84,9 @@ class StoreObserver: NSObject, SKPaymentTransactionObserver {
         }
         
         let result = PurchaseResult.failure(error)
-        completion(result)
+        DispatchQueue.main.async {
+            completion(result)
+        }
     }
     
     private func restored(transaction: SKPaymentTransaction) {


### PR DESCRIPTION
Wrap all completion to main thread for ios 13

In iOS 13 billing library call all completions from background thread which can cause UI crashes.