### PR TITLE
Bug: unfinished transaction loop

### DIFF
--- a/iOS/ApplicasterIAP/StoreObserver.swift
+++ b/iOS/ApplicasterIAP/StoreObserver.swift
@@ -55,7 +55,7 @@ class StoreObserver: NSObject, SKPaymentTransactionObserver {
     private func purchased(transaction: SKPaymentTransaction) {
         let identifier = transaction.payment.productIdentifier
         guard let (purchase, completion) = activePurchases[identifier] else {
-            SKPaymentQueue.default().finishTransaction(transaction)
+            unfinished(transaction: transaction)
             return
         }
         activePurchases.removeValue(forKey: identifier)
@@ -78,6 +78,8 @@ class StoreObserver: NSObject, SKPaymentTransactionObserver {
             unfinished(transaction: transaction)
             return
         }
+        
+        SKPaymentQueue.default().finishTransaction(transaction)
         activePurchases.removeValue(forKey: identifier)
         
         guard let error = transaction.error else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@applicaster/applicaster-iap",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Description
Fix unfinished transaction loop. 

In case transaction Fail it was never finished. This cause unable to start new transaction of same identifier

Test case:

- Try purchase an item
- When window will be presented to fill credentials, push cancel
- It will cause to fail transaction (transaction not finished)
- Try to purchase same item again
- It will cause fail to purchase. In case sandbox. Will show fail can not connect to iTunes Store

Behind the scenes:
After second try to purchase item after cancelation.
When Store Observer added, it try to check unfinished transaction.
Before it happen, function `public func buy(_ purchase: Purchase, completion: @escaping (PurchaseResult) -> Void)`
Will add `activePurchases[purchase.item.productIdentifier] = (purchase, completion)`

Then unfinished transaction will call fail, and since it has same identifier it will get current purchase from `activePurchases`
And send fail to completion.


This fix should resolve issue, but in general it is dangerous implementation.
Another problematic point that library has no way to retrieve delayed transaction that was succeeded in case application was close or crashed 
## Known issues

## Checklist

* [x] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation is included

## QA :

* required test cases:
* specific apps / plugins to test :
